### PR TITLE
Refactor log levels and add documentation

### DIFF
--- a/src/file_size.c
+++ b/src/file_size.c
@@ -1,323 +1,43 @@
-<div align="center">
-
-# OWL API 🍀
-
-<img src="doc/owl.png" width="90%" />
-
-[![Backend CI Pipeline](https://github.com/Nighty3098/owl_backend/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Nighty3098/owl_backend/actions/workflows/ci.yml)
-
-</div>
-
----
-
-## Overview
-
-**OWL_BACKEND** is a microservice-based RESTful API for project, board, and task management, featuring user authentication, subscription management, and admin monitoring. All services are built with Flask, use PostgreSQL, and are orchestrated via Docker Compose.
-
-### Microservices
-
-- **Auth Service** (`:5001`): User registration, authentication, JWT issuing
-- **Users Service** (`:5002`): User profile management
-- **Core Service** (`:5000`): Projects, boards, columns, tasks (CRUD, reordering, color, etc.)
-- **Subscription Service** (`:5004`): Subscription plans and user subscriptions
-- **Backup Service** (`:5005`): Database backup (internal)
-
----
-
-## Features
-
-- JWT authentication (10-year token lifetime)
-- Role-based access (USER, ADMIN)
-- Rate limiting and CORS support
-- Comprehensive logging and error handling
-- Admin endpoints for monitoring and user management
-- Docker Compose orchestration
-
----
-
-# OWL Project Architecture
-
-```mermaid
-graph TB
-    subgraph Frontend["Frontend (Electron)"]
-        E[Electron App<br>React + TypeScript]
-        E -->|HTTPS/WSS| Vercel[Vercel Hosting<br>owl-gamma.vercel.app]
-    end
-
-    subgraph Backend["Backend Services (Docker)"]
-        subgraph API["API Services (Flask)"]
-            API_Gateway[API Gateway<br>nginx/reverse proxy]
-            Core[Core Service<br>:5000<br>Projects, Boards,<br>Tasks, Columns]
-            Auth[Auth Service<br>:5001<br>Login, Register,<br>Token validation]
-            Users[Users Service<br>:5002<br>Profile, Settings,<br>Delete account]
-            Subs[Subscription Service<br>:5003<br>Plans, Billing,<br>Subscriptions]
-        end
-
-        subgraph Data["Data Layer"]
-            PG[(PostgreSQL<br>:5432)]
-            Redis[(Redis<br>:6379)]
-        end
-
-        Backup[Backup Service<br>:5004<br>DB Backups]
-    end
-
-    E -->|POST /api/v1/login| Auth
-    E -->|POST /api/v1/register| Auth
-    E -->|POST /api/v1/check_auth| Auth
-
-    E -->|GET /api/v1/get_boards<br>POST /api/v1/create_task<br>POST /api/v1/edit_task| Core
-    E -->|GET /api/v1/get_projects<br>POST /api/v1/save_project| Core
-
-    E -->|POST /api/v1/change_password<br>POST /api/v1/change_username<br>POST /api/v1/delete| Users
-    E -->|GET /api/v1/get_public_users| Users
-
-    E -->|GET /api/v1/subs<br>GET /api/v1/user_subscription_info| Subs
-
-    Auth -->|Validate Token| PG
-    Core -->|Cache/Rate Limit| Redis
-    Core -->|CRUD| PG
-    Users -->|CRUD| PG
-    Subs -->|CRUD| PG
-    Backup -->|Backup| PG
-
-    API_Gateway -->|Route| Auth
-    API_Gateway -->|Route| Core
-    API_Gateway -->|Route| Users
-    API_Gateway -->|Route| Subs
-```
-
-## Components Description
-
-| Service | Port | Technology | Purpose |
-|---------|------|-------------|---------|
-| **Core Service** | 5000 | Flask + SQLAlchemy | Main API: Projects, Boards, Tasks, Columns, Settings |
-| **Auth Service** | 5001 | Flask | Authentication: Login, Register, Token generation, Ban check |
-| **Users Service** | 5002 | Flask | User management: Profile, Password, Email, Username |
-| **Subscription Service** | 5003 | Flask | Subscriptions: Plans, User subscriptions, Admin controls |
-| **Backup Service** | 5004 | Python | Database backups automation |
-| **PostgreSQL** | 5432 | PostgreSQL 16 | Primary database |
-| **Redis** | 6379 | Redis | Caching, Rate limiting |
-
-## API Endpoints Overview
-
-### Auth Service (`/api/v1/`)
-- `POST /register` - User registration
-- `POST /login` - User login
-- `GET /check_auth` - Token validation
-
-### Core Service (`/api/v1/`)
-- `GET /get_boards` - Get user's boards
-- `POST /create_board` - Create board
-- `POST /create_task` - Create task
-- `POST /edit_task` - Edit task
-- `POST /delete_board` - Delete board
-- `GET /get_projects` - Get projects
-- `POST /save_project` - Save project
-
-### Users Service (`/api/v1/`)
-- `POST /change_password` - Change password
-- `POST /change_username` - Change username
-- `POST /change_email` - Change email
-- `POST /delete` - Delete account
-
-### Subscription Service (`/api/v1/`)
-- `GET /subs` - Get all subscription plans
-- `GET /user_subscription_info` - Get user's subscription
-- `POST /change_user_subscription` - Admin: change user plan
-
----
-
-## Quick Start
-
-### 1. Clone the Repository
-
-```bash
-git clone https://github.com/Nighty3098/OWL_BACKEND
-cd OWL_BACKEND
-```
-
-### 2. Configure Environment Variables
-
-Create a `.env` file in the project root with the following variables:
-
-```ini
-SECRET_KEY=...
-POSTGRES_ROOT_PASSWORD=...
-POSTGRES_USER=...
-POSTGRES_PASSWORD=...
-POSTGRES_DATABASE=...
-FLASK_ENV=production
-SERVICE_PORT=5000
-SERVICE_NAME=core_service
-PG_PORT=5433
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:${PG_PORT}/${POSTGRES_DATABASE}
-AUTH_SERVICE_PORT=5001
-AUTH_SERVICE_NAME=auth_service
-SUBSCRIPTION_SERVICE_PORT=5004
-SUBSCRIPTION_SERVICE_NAME=subscription_service
-USERS_SERVICE_PORT=5002
-USERS_SERVICE_NAME=users_service
-BACKUPS_SERVICE_NAME=backup_service
-BACKUPS_SERVICE_PORT=5005
-```
-
-### 3. (Optional) Generate SSL Certificates (Development Only)
-
-```bash
-mkdir -p certs && certs
-mkcert -install
-mkcert localhost 127.0.0.1 ::1
-```
-
-```bash
-openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
--keyout key.pem -out cert.pem -subj "/CN=YOURIP" \
--addext "subjectAltName=IP:YOURIP"
-```
-
-### 4. Database Migration and Table Creation
-
-The project uses Alembic for database migrations. Tables are automatically created during the first startup:
-
-```bash
-# Build and start all services (includes automatic migration)
-docker-compose build
-docker-compose up
-
-# Or manually run migrations if needed:
-docker-compose run --rm migrate flask --app manage.py db init
-docker-compose run --rm migrate flask --app manage.py db migrate -m "Initial tables"
-docker-compose run --rm migrate flask --app manage.py db upgrade
-```
-
-> **Important:** at the first launch, Docker executes scripts from `db_init_scripts'. They create both a `postgres` system user and a user from the `POSTGRES_USER` variable, so the errors `role "postgres" does not exist` and `password authentication failed for user "<app_user>"`no longer block the download.
-
-**Expected Tables:**
-- `user` - User accounts and authentication
-- `plan` - Subscription plans
-- `subscription` - User subscriptions
-- `project` - User projects
-- `board` - Project boards
-- `column` - Board columns
-- `task` - Column tasks
-- `user_login` - Login history
-- `user_settings` - User preferences
-
-### 5. Verify Database Setup
-
-Check that all tables were created successfully:
-
-```bash
-docker-compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DATABASE -c "\dt"
-```
-
-To stop the services:
-
-```bash
-docker-compose down
-```
-
----
-
-## Architecture
-
-Each microservice runs independently and communicates via REST. All services use Flask + Gunicorn, connect to PostgreSQL, and are managed with Docker Compose. The database is shared via a single PostgreSQL container.
-
-- **API Gateway:** Each service exposes its own port and API endpoints
-- **Stateless:** All authentication is JWT-based
-- **Admin endpoints:** For monitoring, banning users, and database stats
-
----
-
-## Main Endpoints (Core Service)
-
-- `/api/v1/get_projects` — Get all projects for the user
-- `/api/v1/save_projects` — Create or update a project
-- `/api/v1/delete_project` — Delete a project
-- `/api/v1/get_boards` — Get all boards for the user
-- `/api/v1/create_board` — Create a new board
-- `/api/v1/create_column` — Create a new column
-- `/api/v1/create_task` — Create a new task
-- `/api/v1/delete_board` — Delete a board
-- `/api/v1/rename_board` — Rename a board
-- `/api/v1/rename_column` — Rename a column
-- `/api/v1/delete_column` — Delete a column
-- `/api/v1/delete_task` — Delete a task
-- `/api/v1/edit_task` — Edit a task
-- `/api/v1/set_task_completed` — Mark a task as completed
-- `/api/v1/set_column_color` — Set color for a column
-- `/api/v1/set_task_color` — Set color for a task
-- `/api/v1/change_tasks_column` — Move task to another column
-- `/api/v1/reorder_board` — Reorder boards
-- `/api/v1/reorder_column` — Reorder columns
-- `/api/v1/reorder_task` — Reorder tasks
-- `/api/v1/reorder_projects` — Reorder projects
-- `/api/users` — List all users (admin)
-- `/api/ban_user` — Ban/unban user (admin)
-- `/api/database/stats` — Database stats (admin)
-- `/api/database/queries` — Query stats (admin)
-- `/api/usage` — Server usage info (admin)
-- `/api/version` — API version
-- `/api/health` — Health check
-
-> **See [doc/API.md](./doc/API.md) for full endpoint documentation and request/response examples.**
-
----
-
-## Security
-
-- JWT authentication (store tokens securely on the client)
-- Roles: USER, ADMIN (admin endpoints: `/api/usage`, `/api/users`, `/api/ban_user`, `/api/v1/change_user_subscription`)
-- Rate limiting per endpoint
-- CORS and input validation
-- Logging of all requests and errors
-
----
-
-## Error Handling
-
-Standard HTTP status codes and error messages:
-
-- **400 Bad Request:** Invalid request or missing fields
-- **401 Unauthorized:** Invalid credentials or token
-- **403 Forbidden:** Insufficient permissions
-- **404 Not Found:** Resource not found
-- **500 Internal Server Error:** Server-side error
-
----
-
-## Troubleshooting
-
-### Database Tables Not Created?
-
-1. **Check migration status:**
-   ```bash
-   docker-compose exec api flask --app manage.py db current
-   ```
-
-2. **Manual migration:**
-   ```bash
-   docker-compose run --rm migrate flask --app manage.py db stamp head
-   docker-compose run --rm migrate flask --app manage.py db upgrade
-   ```
-
-3. **Force table creation:**
-   ```bash
-   docker-compose exec api python -c "
-   from manage import app, db
-   with app.app_context():
-       db.create_all()
-       print('Tables created successfully')
-   "
-   ```
-
----
-
-## Useful Links
-
-- [Full API Documentation](./doc/API.md)
-- [OWL Web Application](https://owl-gamma.vercel.app/)
-
----
-
-**Built with OWL API 🦉**
+/**
+ * @file file_size.c
+ * @brief File size reporting functionality.
+ *
+ * Provides functions to retrieve and display file size information
+ * in human-readable format.
+ */
+
+#include <stdio.h>
+#include <sys/stat.h>
+
+/**
+ * @brief Prints the size of a file in human-readable format.
+ *
+ * Displays the file size with appropriate units (B, KB, MB, GB, TB)
+ * using a formatted box style.
+ *
+ * @param file_name Path to the file to measure.
+ */
+void print_file_size(const char *file_name)
+{
+    struct stat st;
+    if (stat(file_name, &st) == 0)
+    {
+        long long size = st.st_size;
+        const char *units[] = {"B", "KB", "MB", "GB", "TB"};
+        int unit_index = 0;
+
+        while (size >= 1024 && unit_index < (int)(sizeof(units) / sizeof(units[0])) - 1)
+        {
+            size /= 1024;
+            unit_index++;
+        }
+
+        printf("\033[1;31m\n┌─────────────────────────────⬤ \n");
+        printf("│ ⬤  File size: %.2f %s\n", (double)size, units[unit_index]);
+        printf("└─────────────────────────────⬤ \n\033[0m");
+    }
+    else
+    {
+        perror("\033[1;31m\n\nCould not get file size\033[0m");
+    }
+}

--- a/src/file_size.c
+++ b/src/file_size.c
@@ -1,9 +1,22 @@
+/**
+ * @file file_size.c
+ * @brief File size reporting functionality.
+ *
+ * Provides functions to retrieve and display file size information
+ * in human-readable format.
+ */
+
 #include <stdio.h>
 #include <sys/stat.h>
 
-#define RED "\033[1;31m"
-#define NC "\033[0m"
-
+/**
+ * @brief Prints the size of a file in human-readable format.
+ *
+ * Displays the file size with appropriate units (B, KB, MB, GB, TB)
+ * using a formatted box style.
+ *
+ * @param file_name Path to the file to measure.
+ */
 void print_file_size(const char *file_name)
 {
     struct stat st;
@@ -13,18 +26,18 @@ void print_file_size(const char *file_name)
         const char *units[] = {"B", "KB", "MB", "GB", "TB"};
         int unit_index = 0;
 
-        while (size >= 1024 && unit_index < sizeof(units) / sizeof(units[0]) - 1)
+        while (size >= 1024 && unit_index < (int)(sizeof(units) / sizeof(units[0])) - 1)
         {
             size /= 1024;
             unit_index++;
         }
 
-        printf(RED "\n┌─────────────────────────────⬤ \n│ ⬤  File size: %.2f "
-                   "%s\n└─────────────────────────────⬤ \n" NC,
-               (double)size, units[unit_index]);
+        printf("\033[1;31m\n┌─────────────────────────────⬤ \n");
+        printf("│ ⬤  File size: %.2f %s\n", (double)size, units[unit_index]);
+        printf("└─────────────────────────────⬤ \n\033[0m");
     }
     else
     {
-        perror(RED "\n\nCould not get file size" NC);
+        perror("\033[1;31m\n\nCould not get file size\033[0m");
     }
 }

--- a/src/file_size.h
+++ b/src/file_size.h
@@ -1,6 +1,16 @@
+/**
+ * @file file_size.h
+ * @brief Interface for file size reporting.
+ */
+
 #ifndef FILE_SIZE_H
 #define FILE_SIZE_H
 
+/**
+ * @brief Prints file size in human-readable format.
+ *
+ * @param file_name Path to the file.
+ */
 void print_file_size(const char *file_name);
 
 #endif // FILE_SIZE_H

--- a/src/log_color.c
+++ b/src/log_color.c
@@ -1,45 +1,34 @@
+/**
+ * @file log_color.c
+ * @brief Colorized log output for terminal display.
+ *
+ * Provides functions to colorize log lines based on their log level,
+ * improving readability in terminal output.
+ */
+
 #include "log_color.h"
-#include "log_format.h"
-#include <regex.h>
+#include "log_levels.h"
 #include <stdio.h>
-#include <string.h>
 
-#define RED "\033[0;31m"
-#define YELLOW "\033[1;33m"
-#define GREEN "\033[0;32m"
-#define BLUE "\033[0;34m"
-#define PURPLE "\033[0;35m"
-#define WHITE "\033[1;37m"
-#define ORANGE "\033[38;5;214m"
-#define NC "\033[0m"
-
+/**
+ * @brief Colorizes and prints a log line based on its detected level.
+ *
+ * Searches the log line for known level markers and prints the line
+ * with the corresponding color. Uses pre-compiled regex patterns
+ * for efficient matching.
+ *
+ * @param line The log line to colorize and print. A newline is added
+ *             after the line.
+ */
 void colorize_log(const char *line)
 {
-    regex_t regex;
-
-    const char *level_names[] = {"CRITICAL", "WARNING", "INFO", "DEBUG", "ERROR", "UNKNOWN", "TRACE", "FATAL"};
-    const char *colors[] = {RED, YELLOW, GREEN, BLUE, RED, WHITE, PURPLE, ORANGE};
-
-    for (int i = 0; i < sizeof(level_names) / sizeof(level_names[0]); i++)
+    for (int i = 0; i < LOG_LEVEL_COUNT; i++)
     {
-        char *pattern = get_level_pattern(level_names[i]);
-        int reti;
-        reti = regcomp(&regex, pattern, REG_EXTENDED | REG_ICASE);
-        if (reti)
+        if (log_level_matches(line, (LogLevelType)i))
         {
-            fprintf(stderr, "Could not compile regex\n");
+            printf("%s%s%s\n", LOG_LEVELS[i].color, line, LOG_COLOR_RESET);
             return;
         }
-
-        reti = regexec(&regex, line, 0, NULL, 0);
-        if (reti == 0)
-        {
-            printf("%s%s%s\n", colors[i], line, NC);
-            regfree(&regex);
-            return;
-        }
-        regfree(&regex);
     }
-
     printf("%s\n", line);
 }

--- a/src/log_color.h
+++ b/src/log_color.h
@@ -1,8 +1,19 @@
+/**
+ * @file log_color.h
+ * @brief Interface for colorized log output.
+ */
+
 #ifndef LOG_COLOR_H
 #define LOG_COLOR_H
 
-#include <stdlib.h>
-
+/**
+ * @brief Colorizes and prints a log line based on its level.
+ *
+ * Searches for level markers in the line and applies the corresponding
+ * ANSI color before printing.
+ *
+ * @param line The log line to colorize and print.
+ */
 void colorize_log(const char *line);
 
 #endif // LOG_COLOR_H

--- a/src/log_filter.c
+++ b/src/log_filter.c
@@ -1,17 +1,37 @@
+/**
+ * @file log_filter.c
+ * @brief Log filtering by level and date range.
+ *
+ * Provides functions to filter log lines based on level names
+ * and date/time ranges. Used by the main monitoring loop
+ * to decide which lines to display.
+ */
+
 #define _XOPEN_SOURCE 700
+
+#include "log_filter.h"
+#include "log_format.h"
 #include <ctype.h>
 #include <regex.h>
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-#include "log_format.h"
 
-#define MAX_PATTERN_LENGTH 256
 #define MAX_FILTER_LENGTH 256
 #define DATE_BUFFER_SIZE 64
 
-static int extract_date_from_line(const char *line, const char *date_regex,
-                                  char *date_buf, size_t buf_size)
+/**
+ * @brief Extracts a date substring from a log line.
+ *
+ * Uses a regex to find and extract the date portion of a log line.
+ *
+ * @param line The log line to search.
+ * @param date_regex Regex pattern for the date format.
+ * @param date_buf Output buffer for the extracted date.
+ * @param buf_size Size of the output buffer.
+ * @return 1 on success, 0 on failure.
+ */
+static int extract_date_from_line(const char *line, const char *date_regex, char *date_buf, size_t buf_size)
 {
     regex_t regex;
     if (regcomp(&regex, date_regex, REG_EXTENDED) != 0)
@@ -20,7 +40,7 @@ static int extract_date_from_line(const char *line, const char *date_regex,
     regmatch_t match[1];
     if (regexec(&regex, line, 1, match, 0) == 0)
     {
-        size_t len = match[0].rm_eo - match[0].rm_so;
+        size_t len = (size_t)(match[0].rm_eo - match[0].rm_so);
         if (len >= buf_size)
             len = buf_size - 1;
         memcpy(date_buf, line + match[0].rm_so, len);
@@ -33,6 +53,13 @@ static int extract_date_from_line(const char *line, const char *date_regex,
     return 0;
 }
 
+/**
+ * @brief Parses a date string into a time_t value.
+ *
+ * @param date_str The date string to parse.
+ * @param fmt The strptime format string.
+ * @return Time value, or (time_t)-1 on failure.
+ */
 static time_t parse_date_to_time_t(const char *date_str, const char *fmt)
 {
     struct tm tm = {0};
@@ -41,8 +68,19 @@ static time_t parse_date_to_time_t(const char *date_str, const char *fmt)
     return mktime(&tm);
 }
 
-int should_print_log(const char *line, const char *const filter_levels[],
-                     int filter_count, const char *start_date_str,
+/**
+ * @brief Determines if a log line should be printed.
+ *
+ * Checks the line against filter levels (if any) and date range.
+ *
+ * @param line The log line to check.
+ * @param filter_levels Array of level names to filter by.
+ * @param filter_count Number of filter levels.
+ * @param start_date_str Start of date range (or NULL).
+ * @param end_date_str End of date range (or NULL).
+ * @return 1 if line should be printed, 0 otherwise.
+ */
+int should_print_log(const char *line, char *filter_levels[], int filter_count, const char *start_date_str,
                      const char *end_date_str)
 {
     if (filter_count > 0)
@@ -52,14 +90,15 @@ int should_print_log(const char *line, const char *const filter_levels[],
             char filter_level_lower[MAX_FILTER_LENGTH];
             size_t len = strlen(filter_levels[j]);
 
+            if (len >= MAX_FILTER_LENGTH)
+                len = MAX_FILTER_LENGTH - 1;
+
             for (size_t i = 0; i < len; i++)
-                filter_level_lower[i] = tolower((unsigned char)filter_levels[j][i]);
+                filter_level_lower[i] = (char)tolower((unsigned char)filter_levels[j][i]);
             filter_level_lower[len] = '\0';
 
-            char pattern[MAX_PATTERN_LENGTH];
-            int written = snprintf(pattern, sizeof(pattern),
-                                  "\\|[[:space:]]*%s[[:space:]]*\\|",
-                                  filter_level_lower);
+            char pattern[MAX_FILTER_LENGTH * 2];
+            int written = snprintf(pattern, sizeof(pattern), "\\|[[:space:]]*%s[[:space:]]*\\|", filter_level_lower);
 
             if (written < 0 || (size_t)written >= sizeof(pattern))
                 return 0;
@@ -85,8 +124,7 @@ date_check:
             return 0;
 
         char extracted[DATE_BUFFER_SIZE];
-        if (!extract_date_from_line(line, current_format->date_regex,
-                                    extracted, sizeof(extracted)))
+        if (!extract_date_from_line(line, current_format->date_regex, extracted, sizeof(extracted)))
             return 0;
 
         char *s = extracted;
@@ -105,15 +143,13 @@ date_check:
 
         if (start_date_str)
         {
-            time_t st = parse_date_to_time_t(start_date_str,
-                                            current_format->date_strptime);
+            time_t st = parse_date_to_time_t(start_date_str, current_format->date_strptime);
             if (st == (time_t)-1 || line_ts < st)
                 return 0;
         }
         if (end_date_str)
         {
-            time_t et = parse_date_to_time_t(end_date_str,
-                                            current_format->date_strptime);
+            time_t et = parse_date_to_time_t(end_date_str, current_format->date_strptime);
             if (et == (time_t)-1 || line_ts > et)
                 return 0;
         }

--- a/src/log_filter.h
+++ b/src/log_filter.h
@@ -1,9 +1,23 @@
+/**
+ * @file log_filter.h
+ * @brief Interface for log filtering by level and date range.
+ */
+
 #ifndef LOG_FILTER_H
 #define LOG_FILTER_H
 
 #include <stddef.h>
 
+/**
+ * @brief Checks if a log line passes the filters.
+ *
+ * @param line The log line to check.
+ * @param filter_levels Array of level names to filter by.
+ * @param filter_count Number of filter levels.
+ * @param start_date_str Start of date range (or NULL).
+ * @param end_date_str End of date range (or NULL).
+ * @return Non-zero if line should be printed.
+ */
 int should_print_log(const char *line, char *filter_levels[], int filter_count, const char *start_date_str,
                      const char *end_date_str);
-
 #endif // LOG_FILTER_H

--- a/src/log_format.c
+++ b/src/log_format.c
@@ -1,76 +1,82 @@
+/**
+ * @file log_format.c
+ * @brief Log format definitions and selection.
+ *
+ * Manages supported log formats (basic, Apache, syslog, JSON, custom)
+ * and provides format-specific regex patterns for date and level extraction.
+ */
+
 #include "log_format.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define MAX_FORMATS 10
-#define MAX_PATTERN_LENGTH 512
 
 static LogFormat log_formats[MAX_FORMATS];
 static int format_count = 0;
 LogFormat *current_format = NULL;
 
-void init_log_formats()
+/**
+ * @brief Initializes all supported log formats.
+ *
+ * Registers basic, Apache, syslog, JSON, and custom formats.
+ * Sets the current format to "basic" by default.
+ */
+void init_log_formats(void)
 {
-    LogFormat basic_format = {
-        .name            = "basic",
-        .date_regex      = "\\([0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\\)",
-        .level_regex     = "\\|[[:space:]]*%s[[:space:]]*\\|",
-        .message_regex   = ".*",
-        .level_position  = 1,
-        .date_position   = 0,
-        .message_position= 2,
-        .strict_format   = 0,
-        .date_strptime   = "%Y-%m-%d %H:%M:%S"
-    };
+    LogFormat basic_format = {.name = "basic",
+                              .date_regex = "\\([0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\\)",
+                              .level_regex = "\\|[[:space:]]*%s[[:space:]]*\\|",
+                              .message_regex = ".*",
+                              .level_position = 1,
+                              .date_position = 0,
+                              .message_position = 2,
+                              .strict_format = 0,
+                              .date_strptime = "%Y-%m-%d %H:%M:%S"};
 
     LogFormat apache_format = {
-        .name            = "apache",
-        .date_regex      = "\\(\\[[0-9]{2}/[A-Za-z]{3}/[0-9]{4}:[0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]][+-][0-9]{4}\\]\\)",
-        .level_regex     = "\"[A-Z]+\"",
-        .message_regex   = ".*",
-        .level_position  = 1,
-        .date_position   = 0,
-        .message_position= 2,
-        .strict_format   = 0,
-        .date_strptime   = "%d/%b/%Y:%H:%M:%S %z"
-    };
+        .name = "apache",
+        .date_regex = "\\(\\[[0-9]{2}/[A-Za-z]{3}/[0-9]{4}:[0-9]{2}:[0-9]{2}:[0-9]{2}[[:space:]][+-][0-9]{4}\\]\\)",
+        .level_regex = "\"[A-Z]+\"",
+        .message_regex = ".*",
+        .level_position = 1,
+        .date_position = 0,
+        .message_position = 2,
+        .strict_format = 0,
+        .date_strptime = "%d/%b/%Y:%H:%M:%S %z"};
 
-    LogFormat syslog_format = {
-        .name            = "syslog",
-        .date_regex      = "\\(\\[A-Za-z]{3}[[:space:]]+[0-9]+[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\\)",
-        .level_regex     = "[[:space:]]%s[[:space:]]",
-        .message_regex   = ".*",
-        .level_position  = 1,
-        .date_position   = 0,
-        .message_position= 2,
-        .strict_format   = 0,
-        .date_strptime   = "%b %d %H:%M:%S"
-    };
+    LogFormat syslog_format = {.name = "syslog",
+                               .date_regex =
+                                   "\\(\\[A-Za-z]{3}[[:space:]]+[0-9]+[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\\)",
+                               .level_regex = "[[:space:]]%s[[:space:]]",
+                               .message_regex = ".*",
+                               .level_position = 1,
+                               .date_position = 0,
+                               .message_position = 2,
+                               .strict_format = 0,
+                               .date_strptime = "%b %d %H:%M:%S"};
 
-    LogFormat json_format = {
-        .name            = "json",
-        .date_regex      = "\\(\"timestamp\"[[:space:]]*:[[:space:]]*\"[^\"]+\"\\)",
-        .level_regex     = "\"level\"[[:space:]]*:[[:space:]]*\"%s\"",
-        .message_regex   = "\"message\"[[:space:]]*:[[:space:]]*\"[^\"]+\"",
-        .level_position  = 1,
-        .date_position   = 0,
-        .message_position= 2,
-        .strict_format   = 0,
-        .date_strptime   = "%Y-%m-%dT%H:%M:%SZ"
-    };
+    LogFormat json_format = {.name = "json",
+                             .date_regex = "\\(\"timestamp\"[[:space:]]*:[[:space:]]*\"[^\"]+\"\\)",
+                             .level_regex = "\"level\"[[:space:]]*:[[:space:]]*\"%s\"",
+                             .message_regex = "\"message\"[[:space:]]*:[[:space:]]*\"[^\"]+\"",
+                             .level_position = 1,
+                             .date_position = 0,
+                             .message_position = 2,
+                             .strict_format = 0,
+                             .date_strptime = "%Y-%m-%dT%H:%M:%SZ"};
 
-    LogFormat custom_format = {
-        .name            = "custom",
-        .date_regex      = "([0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3})",
-        .level_regex     = "\\|[[:space:]]*%s[[:space:]]*\\|",
-        .message_regex   = ".*",
-        .level_position  = 1,
-        .date_position   = 0,
-        .message_position= 2,
-        .strict_format   = 0,
-        .date_strptime   = "%Y-%m-%d %H:%M:%S"
-    };
+    LogFormat custom_format = {.name = "custom",
+                               .date_regex =
+                                   "([0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]][0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]{3})",
+                               .level_regex = "\\|[[:space:]]*%s[[:space:]]*\\|",
+                               .message_regex = ".*",
+                               .level_position = 1,
+                               .date_position = 0,
+                               .message_position = 2,
+                               .strict_format = 0,
+                               .date_strptime = "%Y-%m-%d %H:%M:%S"};
 
     log_formats[format_count++] = basic_format;
     log_formats[format_count++] = apache_format;
@@ -81,6 +87,12 @@ void init_log_formats()
     current_format = &log_formats[0];
 }
 
+/**
+ * @brief Selects the active log format by name.
+ *
+ * @param format_name Name of the format to activate.
+ * @return 1 on success, 0 if format not found.
+ */
 int select_log_format(const char *format_name)
 {
     for (int i = 0; i < format_count; i++)
@@ -94,16 +106,27 @@ int select_log_format(const char *format_name)
     return 0;
 }
 
+/**
+ * @brief Generates a regex pattern for a specific level.
+ *
+ * @param level The level name to substitute.
+ * @return Static buffer with the formatted pattern, or NULL on error.
+ */
 char *get_level_pattern(const char *level)
 {
     if (!current_format)
         return NULL;
 
-    static char pattern[MAX_PATTERN_LENGTH];
+    static char pattern[512];
     snprintf(pattern, sizeof(pattern), current_format->level_regex, level);
     return pattern;
 }
 
-void cleanup_log_formats()
+/**
+ * @brief Cleans up format resources.
+ *
+ * Currently a placeholder for future cleanup needs.
+ */
+void cleanup_log_formats(void)
 {
 }

--- a/src/log_levels.c
+++ b/src/log_levels.c
@@ -1,0 +1,80 @@
+/**
+ * @file log_levels.c
+ * @brief Implementation of centralized log level management.
+ *
+ * Provides pre-compiled regex patterns for efficient log level detection
+ * across all modules. This eliminates the previous issue where regex patterns
+ * were recompiled on every log line processed.
+ */
+
+#include "log_levels.h"
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+regex_t LOG_LEVEL_REGEXES[LOG_LEVEL_COUNT];
+
+void log_level_compile_all(void)
+{
+    for (int i = 0; i < LOG_LEVEL_COUNT; i++)
+    {
+        int result = regcomp(&LOG_LEVEL_REGEXES[i], LOG_LEVELS[i].pattern, REG_EXTENDED | REG_ICASE);
+        if (result != 0)
+        {
+            char error_msg[256];
+            regerror(result, &LOG_LEVEL_REGEXES[i], error_msg, sizeof(error_msg));
+            fprintf(stderr, "Failed to compile regex for %s: %s\n", LOG_LEVELS[i].label, error_msg);
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+void log_level_free_all(void)
+{
+    for (int i = 0; i < LOG_LEVEL_COUNT; i++)
+    {
+        regfree(&LOG_LEVEL_REGEXES[i]);
+    }
+}
+
+LogLevelType log_level_from_string(const char *level_name)
+{
+    if (level_name == NULL)
+    {
+        return LOG_LEVEL_UNKNOWN;
+    }
+
+    size_t len = strlen(level_name);
+    if (len == 0)
+    {
+        return LOG_LEVEL_UNKNOWN;
+    }
+
+    char upper[32];
+    size_t copy_len = len < sizeof(upper) - 1 ? len : sizeof(upper) - 1;
+    for (size_t i = 0; i < copy_len; i++)
+    {
+        upper[i] = (char)toupper((unsigned char)level_name[i]);
+    }
+    upper[copy_len] = '\0';
+
+    for (int i = 0; i < LOG_LEVEL_COUNT; i++)
+    {
+        if (strcmp(upper, LOG_LEVELS[i].label) == 0)
+        {
+            return (LogLevelType)i;
+        }
+    }
+
+    return LOG_LEVEL_UNKNOWN;
+}
+
+bool log_level_matches(const char *line, LogLevelType level)
+{
+    if (line == NULL || level < 0 || level >= LOG_LEVEL_COUNT)
+    {
+        return false;
+    }
+    return regexec(&LOG_LEVEL_REGEXES[level], line, 0, NULL, 0) == 0;
+}

--- a/src/log_levels.h
+++ b/src/log_levels.h
@@ -1,0 +1,123 @@
+/**
+ * @file log_levels.h
+ * @brief Centralized log level definitions and color management.
+ *
+ * This file provides a single source of truth for log level types,
+ * their names, colors, and regex patterns used throughout the application.
+ * Previously, this data was duplicated across multiple files.
+ */
+
+#ifndef LOG_LEVELS_H
+#define LOG_LEVELS_H
+
+#include <regex.h>
+#include <stdbool.h>
+
+/**
+ * @brief Enumeration of all supported log levels.
+ *
+ * These values are used to index into the level-related arrays,
+ * ensuring type safety and compile-time checking.
+ */
+typedef enum
+{
+    LOG_LEVEL_CRITICAL = 0,
+    LOG_LEVEL_ERROR = 1,
+    LOG_LEVEL_FATAL = 2,
+    LOG_LEVEL_WARNING = 3,
+    LOG_LEVEL_INFO = 4,
+    LOG_LEVEL_DEBUG = 5,
+    LOG_LEVEL_TRACE = 6,
+    LOG_LEVEL_UNKNOWN = 7,
+    LOG_LEVEL_COUNT = 8
+} LogLevelType;
+
+/**
+ * @brief Structure holding a complete description of a log level.
+ *
+ * Contains all information needed for a log level: its display name,
+ * the ANSI color code for terminal output, and the regex pattern
+ * for detecting this level in log lines.
+ */
+typedef struct
+{
+    const char *label;   /**< Human-readable name (e.g., "ERROR", "WARNING") */
+    const char *color;   /**< ANSI escape code for terminal color */
+    const char *pattern; /**< Regex pattern for detecting this level */
+} LogLevelInfo;
+
+/**
+ * @brief Array containing all log level definitions.
+ *
+ * This is the single source of truth for log level data.
+ * Order must match LogLevelType enum values.
+ */
+static const LogLevelInfo LOG_LEVELS[LOG_LEVEL_COUNT] = {
+    [LOG_LEVEL_CRITICAL] = {"CRITICAL", "\033[1;31m", "\\|\\s*CRITICAL\\s*\\|"},
+    [LOG_LEVEL_ERROR] = {"ERROR", "\033[1;31m", "\\|\\s*ERROR\\s*\\|"},
+    [LOG_LEVEL_FATAL] = {"FATAL", "\033[38;5;214m", "\\|\\s*FATAL\\s*\\|"},
+    [LOG_LEVEL_WARNING] = {"WARNING", "\033[1;33m", "\\|\\s*WARNING\\s*\\|"},
+    [LOG_LEVEL_INFO] = {"INFO", "\033[1;32m", "\\|\\s*INFO\\s*\\|"},
+    [LOG_LEVEL_DEBUG] = {"DEBUG", "\033[1;32m", "\\|\\s*DEBUG\\s*\\|"},
+    [LOG_LEVEL_TRACE] = {"TRACE", "\033[1;34m", "\\|\\s*TRACE\\s*\\|"},
+    [LOG_LEVEL_UNKNOWN] = {"UNKNOWN", "\033[1;37m", "\\|\\s*UNKNOWN\\s*\\|"}};
+
+/**
+ * @brief Global array of pre-compiled regex patterns for log level detection.
+ *
+ * These patterns are compiled once at startup and reused for matching.
+ * Access via log_level_get_pattern() and log_level_compile_all().
+ */
+extern regex_t LOG_LEVEL_REGEXES[LOG_LEVEL_COUNT];
+
+/**
+ * @brief ANSI escape code to reset terminal color.
+ */
+#define LOG_COLOR_RESET "\033[0m"
+
+/**
+ * @brief Compiles all regex patterns for log level detection.
+ *
+ * Should be called once at application startup before any log processing.
+ * If compilation fails, prints error message and terminates the program.
+ */
+void log_level_compile_all(void);
+
+/**
+ * @brief Frees all compiled regex patterns.
+ *
+ * Should be called once at application shutdown to prevent resource leaks.
+ */
+void log_level_free_all(void);
+
+/**
+ * @brief Returns the log level index matching the given level name.
+ *
+ * @param level_name Case-insensitive level name to search for.
+ * @return LogLevelType enum value, or LOG_LEVEL_UNKNOWN if not found.
+ */
+LogLevelType log_level_from_string(const char *level_name);
+
+/**
+ * @brief Checks if a log line contains the specified level marker.
+ *
+ * Uses pre-compiled regex patterns for efficient matching.
+ *
+ * @param line The log line to check.
+ * @param level The log level to search for.
+ * @return true if the line contains the level marker, false otherwise.
+ */
+bool log_level_matches(const char *line, LogLevelType level);
+
+/**
+ * @brief Returns the LogLevelInfo structure for a given level type.
+ *
+ * @param level The log level type.
+ * @return Pointer to the corresponding LogLevelInfo structure.
+ */
+static inline const LogLevelInfo *log_level_get_info(LogLevelType level)
+{
+    return &LOG_LEVELS[level];
+}
+
+#endif // LOG_LEVELS_H

--- a/src/log_monitor.c
+++ b/src/log_monitor.c
@@ -1,12 +1,21 @@
+/**
+ * @file log_monitor.c
+ * @brief Core log monitoring and processing functionality.
+ *
+ * Handles file monitoring, real-time updates via inotify, line processing,
+ * filtering, and statistics collection. This is the main orchestrator
+ * module that coordinates all other components.
+ */
+
 #include "log_monitor.h"
 #include "file_size.h"
 #include "log_color.h"
 #include "log_filter.h"
+#include "log_levels.h"
 #include "log_statistics.h"
 #include "performance_monitor.h"
 #include <errno.h>
 #include <fcntl.h>
-#include <regex.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,15 +30,6 @@
 #define EVENT_SIZE (sizeof(struct inotify_event))
 #define EVENT_BUF_LEN (1024 * EVENT_SIZE)
 
-#define RED "\033[0;31m"
-#define YELLOW "\033[1;33m"
-#define GREEN "\033[0;32m"
-#define BLUE "\033[0;34m"
-#define PURPLE "\033[0;35m"
-#define WHITE "\033[1;37m"
-#define ORANGE "\033[38;5;214m"
-#define NC "\033[0m"
-
 long int critical_count = 0;
 long int warning_count = 0;
 long int info_count = 0;
@@ -39,80 +39,75 @@ long int trace_count = 0;
 long int unknown_count = 0;
 long int fatal_count = 0;
 
-regex_t regex_patterns[8];
 static int running = 1;
 pthread_mutex_t count_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+/**
+ * @brief Signal handler for graceful shutdown.
+ *
+ * Catches SIGINT (Ctrl+C) and sets the running flag to 0,
+ * allowing the main loop to exit cleanly.
+ *
+ * @param signal The signal number received.
+ */
 void handle_signal(int signal)
 {
-    if (signal == SIGINT)
+    (void)signal;
+    if (running)
     {
         running = 0;
-        printf(RED "\n\nBye...\n");
+        printf("\033[1;31m\n\nBye...\n\033[0m");
     }
 }
 
-void compile_regex_patterns()
-{
-    const char *patterns[] = {"\\|\\s*CRITICAL\\s*\\|", "\\|\\s*WARNING\\s*\\|", "\\|\\s*INFO\\s*\\|",
-                              "\\|\\s*DEBUG\\s*\\|",    "\\|\\s*ERROR\\s*\\|",   "\\|\\s*UNKNOWN\\s*\\|",
-                              "\\|\\s*TRACE\\s*\\|",    "\\|\\s*FATAL\\s*\\|"};
-
-    for (int i = 0; i < sizeof(patterns) / sizeof(patterns[0]); i++)
-    {
-        if (regcomp(&regex_patterns[i], patterns[i], REG_EXTENDED | REG_ICASE) != 0)
-        {
-            fprintf(stderr, "Failed to compile regex: %s\n", patterns[i]);
-            exit(EXIT_FAILURE);
-        }
-    }
-}
-
-void free_regex_patterns()
-{
-    for (int i = 0; i < sizeof(regex_patterns) / sizeof(regex_patterns[0]); i++)
-    {
-        regfree(&regex_patterns[i]);
-    }
-}
-
+/**
+ * @brief Increments the count for the matched log level.
+ *
+ * Thread-safe function that uses a mutex to protect the
+ * global count variables. Uses pre-compiled regex patterns
+ * from log_levels.h for efficient matching.
+ *
+ * @param line The log line to analyze.
+ */
 void count_log_levels(const char *line)
 {
     pthread_mutex_lock(&count_mutex);
 
-    int matched = 0;
+    bool matched = false;
 
-    for (int i = 0; i < sizeof(regex_patterns) / sizeof(regex_patterns[0]); i++)
+    for (int i = 0; i < LOG_LEVEL_COUNT; i++)
     {
-        if (regexec(&regex_patterns[i], line, 0, NULL, 0) == 0)
+        if (log_level_matches(line, (LogLevelType)i))
         {
-            matched = 1;
+            matched = true;
             switch (i)
             {
-            case 0:
+            case LOG_LEVEL_CRITICAL:
                 critical_count++;
-                break; // CRITICAL
-            case 1:
+                break;
+            case LOG_LEVEL_WARNING:
                 warning_count++;
-                break; // WARNING
-            case 2:
+                break;
+            case LOG_LEVEL_INFO:
                 info_count++;
-                break; // INFO
-            case 3:
+                break;
+            case LOG_LEVEL_DEBUG:
                 debug_count++;
-                break; // DEBUG
-            case 4:
+                break;
+            case LOG_LEVEL_ERROR:
                 error_count++;
-                break; // ERROR
-            case 5:
+                break;
+            case LOG_LEVEL_UNKNOWN:
                 unknown_count++;
-                break; // UNKNOWN
-            case 6:
+                break;
+            case LOG_LEVEL_TRACE:
                 trace_count++;
-                break; // TRACE
-            case 7:
+                break;
+            case LOG_LEVEL_FATAL:
                 fatal_count++;
-                break; // FATAL
+                break;
+            default:
+                break;
             }
             break;
         }
@@ -126,6 +121,19 @@ void count_log_levels(const char *line)
     pthread_mutex_unlock(&count_mutex);
 }
 
+/**
+ * @brief Processes a single log line through filters and output.
+ *
+ * Checks if the line passes all filters, then either prints it
+ * with colorization or just counts it. Statistics are always updated.
+ *
+ * @param line The log line to process.
+ * @param filter_levels Array of level names to filter by.
+ * @param filter_count Number of filter levels specified.
+ * @param print_lines Whether to actually print matching lines.
+ * @param start_date Start of date range filter (or NULL).
+ * @param end_date End of date range filter (or NULL).
+ */
 void process_line(const char *line, char *filter_levels[], int filter_count, int print_lines,
                   const char *const start_date, const char *const end_date)
 {
@@ -147,18 +155,34 @@ void process_line(const char *line, char *filter_levels[], int filter_count, int
     }
 }
 
+/**
+ * @brief Starts the log monitoring process.
+ *
+ * Opens the specified file (or reads from stdin), optionally enables
+ * real-time monitoring with inotify, processes all lines, and displays
+ * statistics at the end.
+ *
+ * @param file_name Path to log file, or NULL for stdin.
+ * @param filter_levels Array of level names to filter by.
+ * @param filter_count Number of filter levels specified.
+ * @param real_time Enable real-time file monitoring.
+ * @param show_stats Display performance statistics.
+ * @param print_lines Whether to print matching lines.
+ * @param start_date Start of date range filter (or NULL).
+ * @param end_date End of date range filter (or NULL).
+ */
 void start_log_monitor(const char *file_name, char *filter_levels[], int filter_count, int real_time, int show_stats,
                        int print_lines, const char *start_date, const char *end_date)
 {
     signal(SIGINT, handle_signal);
 
-    compile_regex_patterns();
+    log_level_compile_all();
     if (show_stats)
     {
         start_monitoring();
     }
 
-    int use_stdin = (file_name == NULL);
+    bool use_stdin = (file_name == NULL);
     int fd;
     if (use_stdin)
     {
@@ -170,12 +194,20 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
         if (fd == -1)
         {
             perror("open");
-            free_regex_patterns();
+            log_level_free_all();
             return;
         }
     }
 
     char *buffer = malloc(INITIAL_BUFFER_SIZE);
+    if (buffer == NULL)
+    {
+        perror("malloc");
+        if (!use_stdin)
+            close(fd);
+        log_level_free_all();
+        return;
+    }
     size_t buffer_size = INITIAL_BUFFER_SIZE;
     size_t current_length = 0;
 
@@ -187,6 +219,7 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
             perror("inotify_init");
             close(fd);
             free(buffer);
+            log_level_free_all();
             return;
         }
 
@@ -197,6 +230,7 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
             close(fd);
             close(inotify_fd);
             free(buffer);
+            log_level_free_all();
             return;
         }
 
@@ -208,9 +242,7 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
             FD_ZERO(&readfds);
             FD_SET(inotify_fd, &readfds);
 
-            struct timeval tv;
-            tv.tv_sec = 1;
-            tv.tv_usec = 0;
+            struct timeval tv = {1, 0};
 
             int retval = select(inotify_fd + 1, &readfds, NULL, NULL, &tv);
 
@@ -252,7 +284,7 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
                     line_start = line_end + 1;
                 }
 
-                current_length -= (line_start - buffer);
+                current_length -= (size_t)(line_start - buffer);
                 memmove(buffer, line_start, current_length);
                 offset += bytes_read;
             }
@@ -266,7 +298,6 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
     }
     else
     {
-        /* Non‑real‑time read: read until EOF. */
         ssize_t bytes_read;
         while ((bytes_read = read(fd, buffer + current_length, buffer_size - current_length - 1)) > 0)
         {
@@ -283,7 +314,7 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
                 line_start = line_end + 1;
             }
 
-            current_length -= (line_start - buffer);
+            current_length -= (size_t)(line_start - buffer);
             memmove(buffer, line_start, current_length);
         }
 
@@ -295,7 +326,7 @@ void start_log_monitor(const char *file_name, char *filter_levels[], int filter_
         print_statistics();
     }
 
-    free_regex_patterns();
+    log_level_free_all();
     free(buffer);
     if (show_stats)
     {

--- a/src/log_monitor.h
+++ b/src/log_monitor.h
@@ -1,16 +1,56 @@
+/**
+ * @file log_monitor.h
+ * @brief Interface for the core log monitoring module.
+ */
+
 #ifndef LOG_MONITOR_H
 #define LOG_MONITOR_H
 
 #include <pthread.h>
 
+/**
+ * @brief Starts monitoring and processing a log file.
+ *
+ * @param file_name Path to log file, or NULL for stdin.
+ * @param filter_levels Array of level names to filter by.
+ * @param filter_count Number of filter levels specified.
+ * @param real_time Enable real-time file monitoring.
+ * @param show_stats Display performance statistics.
+ * @param print_lines Whether to print matching lines.
+ * @param start_date Start of date range filter (or NULL).
+ * @param end_date End of date range filter (or NULL).
+ */
 void start_log_monitor(const char *file_name, char *filter_levels[], int filter_count, int real_time, int show_stats,
                        int print_lines, const char *start_date, const char *end_date);
-void process_line(const char *line, char *filter_levels[], int filter_count, int print_lines, 
-                 const char *start_date, const char *end_date);
+
+/**
+ * @brief Processes a single log line.
+ *
+ * @param line The log line to process.
+ * @param filter_levels Array of level names to filter by.
+ * @param filter_count Number of filter levels specified.
+ * @param print_lines Whether to print matching lines.
+ * @param start_date Start of date range filter (or NULL).
+ * @param end_date End of date range filter (or NULL).
+ */
+void process_line(const char *line, char *filter_levels[], int filter_count, int print_lines, const char *start_date,
+                  const char *end_date);
+
+/**
+ * @brief Counts the log line by its detected level.
+ *
+ * @param line The log line to analyze.
+ */
 void count_log_levels(const char *line);
 
+/**
+ * @brief Mutex for thread-safe count operations.
+ */
 extern pthread_mutex_t count_mutex;
 
+/**
+ * @brief Count variables for each log level.
+ */
 extern long int critical_count;
 extern long int warning_count;
 extern long int info_count;

--- a/src/log_statistics.c
+++ b/src/log_statistics.c
@@ -1,323 +1,80 @@
-<div align="center">
-
-# OWL API 🍀
-
-<img src="doc/owl.png" width="90%" />
-
-[![Backend CI Pipeline](https://github.com/Nighty3098/owl_backend/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Nighty3098/owl_backend/actions/workflows/ci.yml)
-
-</div>
-
----
-
-## Overview
-
-**OWL_BACKEND** is a microservice-based RESTful API for project, board, and task management, featuring user authentication, subscription management, and admin monitoring. All services are built with Flask, use PostgreSQL, and are orchestrated via Docker Compose.
-
-### Microservices
-
-- **Auth Service** (`:5001`): User registration, authentication, JWT issuing
-- **Users Service** (`:5002`): User profile management
-- **Core Service** (`:5000`): Projects, boards, columns, tasks (CRUD, reordering, color, etc.)
-- **Subscription Service** (`:5004`): Subscription plans and user subscriptions
-- **Backup Service** (`:5005`): Database backup (internal)
-
----
-
-## Features
-
-- JWT authentication (10-year token lifetime)
-- Role-based access (USER, ADMIN)
-- Rate limiting and CORS support
-- Comprehensive logging and error handling
-- Admin endpoints for monitoring and user management
-- Docker Compose orchestration
-
----
-
-# OWL Project Architecture
-
-```mermaid
-graph TB
-    subgraph Frontend["Frontend (Electron)"]
-        E[Electron App<br>React + TypeScript]
-        E -->|HTTPS/WSS| Vercel[Vercel Hosting<br>owl-gamma.vercel.app]
-    end
-
-    subgraph Backend["Backend Services (Docker)"]
-        subgraph API["API Services (Flask)"]
-            API_Gateway[API Gateway<br>nginx/reverse proxy]
-            Core[Core Service<br>:5000<br>Projects, Boards,<br>Tasks, Columns]
-            Auth[Auth Service<br>:5001<br>Login, Register,<br>Token validation]
-            Users[Users Service<br>:5002<br>Profile, Settings,<br>Delete account]
-            Subs[Subscription Service<br>:5003<br>Plans, Billing,<br>Subscriptions]
-        end
-
-        subgraph Data["Data Layer"]
-            PG[(PostgreSQL<br>:5432)]
-            Redis[(Redis<br>:6379)]
-        end
-
-        Backup[Backup Service<br>:5004<br>DB Backups]
-    end
-
-    E -->|POST /api/v1/login| Auth
-    E -->|POST /api/v1/register| Auth
-    E -->|POST /api/v1/check_auth| Auth
-
-    E -->|GET /api/v1/get_boards<br>POST /api/v1/create_task<br>POST /api/v1/edit_task| Core
-    E -->|GET /api/v1/get_projects<br>POST /api/v1/save_project| Core
-
-    E -->|POST /api/v1/change_password<br>POST /api/v1/change_username<br>POST /api/v1/delete| Users
-    E -->|GET /api/v1/get_public_users| Users
-
-    E -->|GET /api/v1/subs<br>GET /api/v1/user_subscription_info| Subs
-
-    Auth -->|Validate Token| PG
-    Core -->|Cache/Rate Limit| Redis
-    Core -->|CRUD| PG
-    Users -->|CRUD| PG
-    Subs -->|CRUD| PG
-    Backup -->|Backup| PG
-
-    API_Gateway -->|Route| Auth
-    API_Gateway -->|Route| Core
-    API_Gateway -->|Route| Users
-    API_Gateway -->|Route| Subs
-```
-
-## Components Description
-
-| Service | Port | Technology | Purpose |
-|---------|------|-------------|---------|
-| **Core Service** | 5000 | Flask + SQLAlchemy | Main API: Projects, Boards, Tasks, Columns, Settings |
-| **Auth Service** | 5001 | Flask | Authentication: Login, Register, Token generation, Ban check |
-| **Users Service** | 5002 | Flask | User management: Profile, Password, Email, Username |
-| **Subscription Service** | 5003 | Flask | Subscriptions: Plans, User subscriptions, Admin controls |
-| **Backup Service** | 5004 | Python | Database backups automation |
-| **PostgreSQL** | 5432 | PostgreSQL 16 | Primary database |
-| **Redis** | 6379 | Redis | Caching, Rate limiting |
-
-## API Endpoints Overview
-
-### Auth Service (`/api/v1/`)
-- `POST /register` - User registration
-- `POST /login` - User login
-- `GET /check_auth` - Token validation
-
-### Core Service (`/api/v1/`)
-- `GET /get_boards` - Get user's boards
-- `POST /create_board` - Create board
-- `POST /create_task` - Create task
-- `POST /edit_task` - Edit task
-- `POST /delete_board` - Delete board
-- `GET /get_projects` - Get projects
-- `POST /save_project` - Save project
-
-### Users Service (`/api/v1/`)
-- `POST /change_password` - Change password
-- `POST /change_username` - Change username
-- `POST /change_email` - Change email
-- `POST /delete` - Delete account
-
-### Subscription Service (`/api/v1/`)
-- `GET /subs` - Get all subscription plans
-- `GET /user_subscription_info` - Get user's subscription
-- `POST /change_user_subscription` - Admin: change user plan
-
----
-
-## Quick Start
-
-### 1. Clone the Repository
-
-```bash
-git clone https://github.com/Nighty3098/OWL_BACKEND
-cd OWL_BACKEND
-```
-
-### 2. Configure Environment Variables
-
-Create a `.env` file in the project root with the following variables:
-
-```ini
-SECRET_KEY=...
-POSTGRES_ROOT_PASSWORD=...
-POSTGRES_USER=...
-POSTGRES_PASSWORD=...
-POSTGRES_DATABASE=...
-FLASK_ENV=production
-SERVICE_PORT=5000
-SERVICE_NAME=core_service
-PG_PORT=5433
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:${PG_PORT}/${POSTGRES_DATABASE}
-AUTH_SERVICE_PORT=5001
-AUTH_SERVICE_NAME=auth_service
-SUBSCRIPTION_SERVICE_PORT=5004
-SUBSCRIPTION_SERVICE_NAME=subscription_service
-USERS_SERVICE_PORT=5002
-USERS_SERVICE_NAME=users_service
-BACKUPS_SERVICE_NAME=backup_service
-BACKUPS_SERVICE_PORT=5005
-```
-
-### 3. (Optional) Generate SSL Certificates (Development Only)
-
-```bash
-mkdir -p certs && certs
-mkcert -install
-mkcert localhost 127.0.0.1 ::1
-```
-
-```bash
-openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes \
--keyout key.pem -out cert.pem -subj "/CN=YOURIP" \
--addext "subjectAltName=IP:YOURIP"
-```
-
-### 4. Database Migration and Table Creation
-
-The project uses Alembic for database migrations. Tables are automatically created during the first startup:
-
-```bash
-# Build and start all services (includes automatic migration)
-docker-compose build
-docker-compose up
-
-# Or manually run migrations if needed:
-docker-compose run --rm migrate flask --app manage.py db init
-docker-compose run --rm migrate flask --app manage.py db migrate -m "Initial tables"
-docker-compose run --rm migrate flask --app manage.py db upgrade
-```
-
-> **Important:** at the first launch, Docker executes scripts from `db_init_scripts'. They create both a `postgres` system user and a user from the `POSTGRES_USER` variable, so the errors `role "postgres" does not exist` and `password authentication failed for user "<app_user>"`no longer block the download.
-
-**Expected Tables:**
-- `user` - User accounts and authentication
-- `plan` - Subscription plans
-- `subscription` - User subscriptions
-- `project` - User projects
-- `board` - Project boards
-- `column` - Board columns
-- `task` - Column tasks
-- `user_login` - Login history
-- `user_settings` - User preferences
-
-### 5. Verify Database Setup
-
-Check that all tables were created successfully:
-
-```bash
-docker-compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DATABASE -c "\dt"
-```
-
-To stop the services:
-
-```bash
-docker-compose down
-```
-
----
-
-## Architecture
-
-Each microservice runs independently and communicates via REST. All services use Flask + Gunicorn, connect to PostgreSQL, and are managed with Docker Compose. The database is shared via a single PostgreSQL container.
-
-- **API Gateway:** Each service exposes its own port and API endpoints
-- **Stateless:** All authentication is JWT-based
-- **Admin endpoints:** For monitoring, banning users, and database stats
-
----
-
-## Main Endpoints (Core Service)
-
-- `/api/v1/get_projects` — Get all projects for the user
-- `/api/v1/save_projects` — Create or update a project
-- `/api/v1/delete_project` — Delete a project
-- `/api/v1/get_boards` — Get all boards for the user
-- `/api/v1/create_board` — Create a new board
-- `/api/v1/create_column` — Create a new column
-- `/api/v1/create_task` — Create a new task
-- `/api/v1/delete_board` — Delete a board
-- `/api/v1/rename_board` — Rename a board
-- `/api/v1/rename_column` — Rename a column
-- `/api/v1/delete_column` — Delete a column
-- `/api/v1/delete_task` — Delete a task
-- `/api/v1/edit_task` — Edit a task
-- `/api/v1/set_task_completed` — Mark a task as completed
-- `/api/v1/set_column_color` — Set color for a column
-- `/api/v1/set_task_color` — Set color for a task
-- `/api/v1/change_tasks_column` — Move task to another column
-- `/api/v1/reorder_board` — Reorder boards
-- `/api/v1/reorder_column` — Reorder columns
-- `/api/v1/reorder_task` — Reorder tasks
-- `/api/v1/reorder_projects` — Reorder projects
-- `/api/users` — List all users (admin)
-- `/api/ban_user` — Ban/unban user (admin)
-- `/api/database/stats` — Database stats (admin)
-- `/api/database/queries` — Query stats (admin)
-- `/api/usage` — Server usage info (admin)
-- `/api/version` — API version
-- `/api/health` — Health check
-
-> **See [doc/API.md](./doc/API.md) for full endpoint documentation and request/response examples.**
-
----
-
-## Security
-
-- JWT authentication (store tokens securely on the client)
-- Roles: USER, ADMIN (admin endpoints: `/api/usage`, `/api/users`, `/api/ban_user`, `/api/v1/change_user_subscription`)
-- Rate limiting per endpoint
-- CORS and input validation
-- Logging of all requests and errors
-
----
-
-## Error Handling
-
-Standard HTTP status codes and error messages:
-
-- **400 Bad Request:** Invalid request or missing fields
-- **401 Unauthorized:** Invalid credentials or token
-- **403 Forbidden:** Insufficient permissions
-- **404 Not Found:** Resource not found
-- **500 Internal Server Error:** Server-side error
-
----
-
-## Troubleshooting
-
-### Database Tables Not Created?
-
-1. **Check migration status:**
-   ```bash
-   docker-compose exec api flask --app manage.py db current
-   ```
-
-2. **Manual migration:**
-   ```bash
-   docker-compose run --rm migrate flask --app manage.py db stamp head
-   docker-compose run --rm migrate flask --app manage.py db upgrade
-   ```
-
-3. **Force table creation:**
-   ```bash
-   docker-compose exec api python -c "
-   from manage import app, db
-   with app.app_context():
-       db.create_all()
-       print('Tables created successfully')
-   "
-   ```
-
----
-
-## Useful Links
-
-- [Full API Documentation](./doc/API.md)
-- [OWL Web Application](https://owl-gamma.vercel.app/)
-
----
-
-**Built with OWL API 🦉**
+/**
+ * @file log_statistics.c
+ * @brief Log statistics collection and reporting.
+ *
+ * Tracks and displays statistics about processed log lines,
+ * organized by log level.
+ */
+
+#include "log_statistics.h"
+#include "log_levels.h"
+#include <stdio.h>
+
+/**
+ * @brief Counts for each log level.
+ *
+ * These are defined in log_monitor.c and externed here.
+ */
+extern long int critical_count;
+extern long int warning_count;
+extern long int info_count;
+extern long int error_count;
+extern long int debug_count;
+extern long int trace_count;
+extern long int unknown_count;
+extern long int fatal_count;
+
+/**
+ * @brief Maps log level types to their corresponding count variables.
+ *
+ * Provides access to count variables by log level index.
+ *
+ * @param level The log level type.
+ * @return Pointer to the count variable for the given level.
+ */
+static long int *get_count_ptr(LogLevelType level)
+{
+    switch (level)
+    {
+    case LOG_LEVEL_CRITICAL:
+        return &critical_count;
+    case LOG_LEVEL_ERROR:
+        return &error_count;
+    case LOG_LEVEL_FATAL:
+        return &fatal_count;
+    case LOG_LEVEL_WARNING:
+        return &warning_count;
+    case LOG_LEVEL_INFO:
+        return &info_count;
+    case LOG_LEVEL_DEBUG:
+        return &debug_count;
+    case LOG_LEVEL_TRACE:
+        return &trace_count;
+    case LOG_LEVEL_UNKNOWN:
+    default:
+        return &unknown_count;
+    }
+}
+
+/**
+ * @brief Prints formatted statistics for all log levels.
+ *
+ * Displays a summary table of log counts, only showing levels
+ * with non-zero counts. Output is colorized by level.
+ */
+void print_statistics(void)
+{
+    printf("\033[1;34m┌─────────────────────────────⬤ \n");
+    printf("│    Log Statistics:\n");
+
+    for (int i = 0; i < LOG_LEVEL_COUNT; i++)
+    {
+        long int *count = get_count_ptr((LogLevelType)i);
+        if (*count > 0)
+        {
+            printf("\033[0;34m│%s ⬤ %s: %ld\n", LOG_LEVELS[i].color, LOG_LEVELS[i].label, *count);
+        }
+    }
+
+    printf("\033[1;34m└─────────────────────────────⬤ \n");
+}

--- a/src/log_statistics.c
+++ b/src/log_statistics.c
@@ -1,5 +1,20 @@
-#include "log_statistics.h"
+/**
+ * @file log_statistics.c
+ * @brief Log statistics collection and reporting.
+ *
+ * Tracks and displays statistics about processed log lines,
+ * organized by log level.
+ */
 
+#include "log_statistics.h"
+#include "log_levels.h"
+#include <stdio.h>
+
+/**
+ * @brief Counts for each log level.
+ *
+ * These are defined in log_monitor.c and externed here.
+ */
 extern long int critical_count;
 extern long int warning_count;
 extern long int info_count;
@@ -9,26 +24,55 @@ extern long int trace_count;
 extern long int unknown_count;
 extern long int fatal_count;
 
-void print_statistics()
+/**
+ * @brief Maps log level types to their corresponding count variables.
+ *
+ * Provides access to count variables by log level index.
+ *
+ * @param level The log level type.
+ * @return Pointer to the count variable for the given level.
+ */
+static long int *get_count_ptr(LogLevelType level)
 {
-    LogLevel log_levels[] = {
-        {"CRITICAL", critical_count, "\033[1;31m"}, // RED
-        {"ERROR", error_count, "\033[1;31m"},       // RED
-        {"FATAL", fatal_count, "\033[38;5;214m"},   // ORANGE
-        {"WARNING", warning_count, "\033[1;33m"},   // YELLOW
-        {"INFO", info_count, "\033[1;32m"},         // GREEN
-        {"TRACE", trace_count, "\033[1;34m"},       // BLUE
-        {"DEBUG", debug_count, "\033[1;32m"},       // GREEN
-        {"UNKNOWN", unknown_count, "\033[1;37m"}    // WHITE
-    };
-
-    printf("\033[1;34m┌─────────────────────────────⬤ \n│    Log Statistics:\n");
-
-    for (int i = 0; i < sizeof(log_levels) / sizeof(log_levels[0]); i++)
+    switch (level)
     {
-        if (log_levels[i].count > 0)
+    case LOG_LEVEL_CRITICAL:
+        return &critical_count;
+    case LOG_LEVEL_ERROR:
+        return &error_count;
+    case LOG_LEVEL_FATAL:
+        return &fatal_count;
+    case LOG_LEVEL_WARNING:
+        return &warning_count;
+    case LOG_LEVEL_INFO:
+        return &info_count;
+    case LOG_LEVEL_DEBUG:
+        return &debug_count;
+    case LOG_LEVEL_TRACE:
+        return &trace_count;
+    case LOG_LEVEL_UNKNOWN:
+    default:
+        return &unknown_count;
+    }
+}
+
+/**
+ * @brief Prints formatted statistics for all log levels.
+ *
+ * Displays a summary table of log counts, only showing levels
+ * with non-zero counts. Output is colorized by level.
+ */
+void print_statistics(void)
+{
+    printf("\033[1;34m┌─────────────────────────────⬤ \n");
+    printf("│    Log Statistics:\n");
+
+    for (int i = 0; i < LOG_LEVEL_COUNT; i++)
+    {
+        long int *count = get_count_ptr((LogLevelType)i);
+        if (*count > 0)
         {
-            printf("\033[0;34m│%s ⬤ %s: %ld\n", log_levels[i].color, log_levels[i].label, log_levels[i].count);
+            printf("\033[0;34m│%s ⬤ %s: %ld\n", LOG_LEVELS[i].color, LOG_LEVELS[i].label, *count);
         }
     }
 

--- a/src/log_statistics.h
+++ b/src/log_statistics.h
@@ -1,15 +1,19 @@
+/**
+ * @file log_statistics.h
+ * @brief Interface for log statistics tracking and reporting.
+ */
+
 #ifndef LOG_STATISTICS_H
 #define LOG_STATISTICS_H
 
 #include <stdio.h>
 
-typedef struct
-{
-    const char *label;
-    long int count;
-    const char *color;
-} LogLevel;
-
-void print_statistics();
+/**
+ * @brief Prints formatted statistics for all processed log levels.
+ *
+ * Shows a summary of log line counts by level, with non-zero levels
+ * displayed in their respective colors.
+ */
+void print_statistics(void);
 
 #endif // LOG_STATISTICS_H

--- a/src/performance_monitor.c
+++ b/src/performance_monitor.c
@@ -1,17 +1,38 @@
+/**
+ * @file performance_monitor.c
+ * @brief Performance monitoring and reporting.
+ *
+ * Tracks CPU time, elapsed time, and memory usage of the application,
+ * providing performance statistics at the end of execution.
+ */
+
 #include "performance_monitor.h"
+#include <stdio.h>
+#include <sys/resource.h>
+#include <sys/time.h>
 
 static struct timeval start_time;
 static struct rusage start_usage;
 
-#define GREEN "\033[1;32m"
-
-void start_monitoring()
+/**
+ * @brief Starts performance monitoring.
+ *
+ * Captures the initial time and resource usage to calculate
+ * performance metrics later. Should be called once at startup.
+ */
+void start_monitoring(void)
 {
     gettimeofday(&start_time, NULL);
     getrusage(RUSAGE_SELF, &start_usage);
 }
 
-void stop_monitoring()
+/**
+ * @brief Stops monitoring and prints performance statistics.
+ *
+ * Calculates elapsed time, CPU time, and peak memory usage
+ * since start_monitoring() was called, then prints formatted output.
+ */
+void stop_monitoring(void)
 {
     struct timeval end_time;
     struct rusage end_usage;
@@ -19,61 +40,38 @@ void stop_monitoring()
     gettimeofday(&end_time, NULL);
     getrusage(RUSAGE_SELF, &end_usage);
 
-    long seconds = end_time.tv_sec - start_time.tv_sec;
-    long microseconds = end_time.tv_usec - start_time.tv_usec;
-    double elapsed = seconds + microseconds * 1e-6;
+    double elapsed = (end_time.tv_sec - start_time.tv_sec) + (end_time.tv_usec - start_time.tv_usec) * 1e-6;
 
     long memory_used = end_usage.ru_maxrss;
 
-    long user_cpu_time = end_usage.ru_utime.tv_sec * 1000000 + end_usage.ru_utime.tv_usec;
-    long system_cpu_time = end_usage.ru_stime.tv_sec * 1000000 + end_usage.ru_stime.tv_usec;
-    double cpu_time = (user_cpu_time + system_cpu_time) / 1000000.0;
+    double user_cpu = end_usage.ru_utime.tv_sec + end_usage.ru_utime.tv_usec * 1e-6;
+    double sys_cpu = end_usage.ru_stime.tv_sec + end_usage.ru_stime.tv_usec * 1e-6;
+    double cpu_time = user_cpu + sys_cpu;
 
-    printf(GREEN "┌─────────────────────────────⬤ \n");
+    printf("\033[1;32m┌─────────────────────────────⬤ \n");
+
     if (elapsed < 1.0)
-    {
         printf("│ ⬤  Elapsed time: %.3f milliseconds\n", elapsed * 1000);
-    }
     else if (elapsed < 60.0)
-    {
         printf("│ ⬤  Elapsed time: %.3f seconds\n", elapsed);
-    }
     else if (elapsed < 3600.0)
-    {
-        double minutes = elapsed / 60.0;
-        printf("│ ⬤  Elapsed time: %.3f minutes\n", minutes);
-    }
+        printf("│ ⬤  Elapsed time: %.3f minutes\n", elapsed / 60.0);
     else if (elapsed < 86400.0)
-    {
-        double hours = elapsed / 3600.0;
-        printf("│ ⬤  Elapsed time: %.3f hours\n", hours);
-    }
+        printf("│ ⬤  Elapsed time: %.3f hours\n", elapsed / 3600.0);
     else
-    {
-        double days = elapsed / 86400.0;
-        printf("│ ⬤  Elapsed time: %.3f days\n", days);
-    }
+        printf("│ ⬤  Elapsed time: %.3f days\n", elapsed / 86400.0);
 
     if (memory_used < 1024)
-    {
         printf("│ ⬤  Memory used: %ld bytes\n", memory_used);
-    }
     else if (memory_used < 1024 * 1024)
-    {
         printf("│ ⬤  Memory used: %.2f KB\n", memory_used / 1024.0);
-    }
     else
-    {
         printf("│ ⬤  Memory used: %.2f MB\n", memory_used / (1024.0 * 1024.0));
-    }
 
     if (cpu_time < 1.0)
-    {
         printf("│ ⬤  CPU time: %.3f milliseconds\n", cpu_time * 1000);
-    }
     else
-    {
         printf("│ ⬤  CPU time: %.3f seconds\n", cpu_time);
-    }
+
     printf("└─────────────────────────────⬤ \n");
 }

--- a/src/performance_monitor.h
+++ b/src/performance_monitor.h
@@ -1,12 +1,24 @@
+/**
+ * @file performance_monitor.h
+ * @brief Interface for performance monitoring.
+ */
+
 #ifndef PERFORMANCE_MONITOR_H
 #define PERFORMANCE_MONITOR_H
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <sys/resource.h>
 #include <sys/time.h>
 
-void start_monitoring();
-void stop_monitoring();
+/**
+ * @brief Starts performance monitoring.
+ *
+ * Captures initial resource usage for later comparison.
+ */
+void start_monitoring(void);
+
+/**
+ * @brief Stops monitoring and prints statistics.
+ */
+void stop_monitoring(void);
 
 #endif // PERFORMANCE_MONITOR_H


### PR DESCRIPTION
- Centralize log level definitions in new log_levels.h/c module
  - Add LogLevelType enum with all supported levels
  - Define LOG_LEVELS array as single source of truth
  - Pre-compile regex patterns at startup (fixes per-line recompilation)
- Remove code duplication:
  - Level name arrays previously defined 3 times
  - Color definitions previously scattered across 4 files
- Add Doxygen-style documentation to all functions
- Fix buffer overflow potential in filter_level_lower
- Use centralized LOG_LEVELS data in log_color, log_statistics, log_monitor